### PR TITLE
docs: 謝辞に未踏ジュニアを追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -335,3 +335,4 @@ pytest
 - [PLATEAU](https://www.mlit.go.jp/plateau/) — 国交省 3D 都市モデル
 - [OpenCASCADE](https://www.opencascade.com/) / [pythonocc-core](https://github.com/tpaviot/pythonocc-core) — STEP 変換の CAD カーネル
 - [pyproj](https://pyproj4.github.io/pyproj/) — 座標参照系変換
+- [未踏ジュニア](https://jr.mitou.org/) — 独創的アイデアと卓越した技術を持つ 17 歳以下のクリエータ支援プログラム

--- a/README.md
+++ b/README.md
@@ -338,3 +338,4 @@ gml2step was originally developed as part of [Paper-CAD](https://github.com/Soyn
 - [PLATEAU](https://www.mlit.go.jp/plateau/) — Japan's national 3D city model project (MLIT)
 - [OpenCASCADE](https://www.opencascade.com/) / [pythonocc-core](https://github.com/tpaviot/pythonocc-core) — 3D CAD kernel for STEP conversion
 - [pyproj](https://pyproj4.github.io/pyproj/) — Coordinate reference system transformations
+- [Mitou Junior](https://jr.mitou.org/) — A program supporting creators aged 17 and under with original ideas and outstanding technical skills


### PR DESCRIPTION
## Summary
- README.md / README.ja.md の謝辞セクションに未踏ジュニア (Mitou Junior) を追加