### PR TITLE
docs: improve landing page messaging and use cases

### DIFF
--- a/docs/src/content/docs/en/index.mdx
+++ b/docs/src/content/docs/en/index.mdx
@@ -4,7 +4,7 @@ description: CityGML to STEP conversion toolkit
 template: splash
 hero:
   title: gml2step
-  tagline: CityGML parsing and STEP conversion for CAD/BIM workflows
+  tagline: Convert CityGML to STEP. Make PLATEAU data editable in CAD
   actions:
     - text: Get started
       link: /gml2step/en/installation/
@@ -16,22 +16,37 @@ hero:
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
-## What it does
+## About this tool
 
-gml2step reads CityGML 2.0 files and produces STEP (ISO 10303-21) files suitable for CAD/CAM/BIM software. It handles Japan's [PLATEAU](https://www.mlit.go.jp/plateau/) large-scale 3D city model datasets out of the box.
+gml2step is a **Python library & command-line tool** for converting CityGML to STEP (ISO 10303-21). It provides both a Python API and CLI interface, allowing you to choose the best approach for your workflow.
+
+## What you can achieve
+
+The **world's first** open-source CityGML → STEP conversion implementation makes Japan's [PLATEAU](https://www.mlit.go.jp/plateau/) 3D city models **editable in standard CAD software**. Transform "view-only" PLATEAU data into fully editable models in your CAD/BIM environment.
+
+### Use cases
+
+- **Architectural design**: Import PLATEAU building data into CAD for renovation planning and urban development projects
+- **3D printing**: Adjust and optimize building models in CAD to create printable data
+- **Simulation & analysis**: Feed models into CAD/CAE tools for structural, thermal, or acoustic simulation
+- **Customization**: Use real-world building data as a foundation for design modifications and extensions
 
 <CardGrid>
-  <Card title="Parse" icon="document">
-    Stream-parse CityGML files of any size with constant memory usage. Extract building metadata, footprints, and geometry without loading the entire DOM.
+  <Card title="As a library" icon="rocket">
+    Embed in Python projects to automate CityGML parsing, conversion, and data extraction.
+    Streaming API keeps memory usage constant even for massive datasets.
   </Card>
-  <Card title="Convert" icon="setting">
-    Transform 3D building geometry to STEP via OpenCASCADE. Four conversion methods with automatic LoD fallback and progressive geometry repair.
+  <Card title="As a CLI tool" icon="laptop">
+    One command to convert CityGML to STEP. Integrate into scripts and pipelines
+    for batch processing and workflow automation.
   </Card>
-  <Card title="Fetch" icon="magnifier">
-    Download CityGML data from PLATEAU's public API by address or mesh code. Geocoding, ranking, and caching included.
+  <Card title="PLATEAU integration" icon="magnifier">
+    Fetch CityGML directly from PLATEAU's public API using addresses or mesh codes.
+    Access 3D city models across Japan.
   </Card>
-  <Card title="Extract" icon="list-format">
-    Pull 2D footprints with height estimates from CityGML — no OCCT dependency required.
+  <Card title="Flexible conversion" icon="setting">
+    Four conversion methods, automatic LoD fallback, and progressive geometry repair
+    handle CityGML data of varying quality.
   </Card>
 </CardGrid>
 
@@ -43,7 +58,7 @@ gml2step reads CityGML 2.0 files and produces STEP (ISO 10303-21) files suitable
 # Parse and summarize
 gml2step parse ./building.gml
 
-# Convert to STEP
+# Convert to STEP (open in CAD)
 gml2step convert ./building.gml ./output.step --method auto
 
 # Extract 2D footprints
@@ -60,6 +75,6 @@ summary = parse("building.gml")
 for building, xlinks in stream_parse("building.gml"):
     process(building)
 
-# Full conversion
+# Convert to STEP (editable in CAD)
 ok, msg = convert("building.gml", "output.step", method="auto")
 ```

--- a/docs/src/content/docs/ja/index.mdx
+++ b/docs/src/content/docs/ja/index.mdx
@@ -4,7 +4,7 @@ description: CityGML を STEP に変換するツールキット
 template: splash
 hero:
   title: gml2step
-  tagline: CityGML のパースと STEP 変換。CAD/BIM ワークフロー向け。
+  tagline: CityGML を STEP に変換。PLATEAU データを CAD で編集可能に
   actions:
     - text: はじめる
       link: /gml2step/ja/installation/
@@ -16,22 +16,37 @@ hero:
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
-## 何ができるか
+## このツールについて
 
-CityGML 2.0 ファイルを読み込んで、CAD/BIM で使える STEP (ISO 10303-21) ファイルに変換します。国交省 [PLATEAU](https://www.mlit.go.jp/plateau/) の大規模データにも対応しています。
+gml2step は、CityGML から STEP (ISO 10303-21) への変換を実現する **Python ライブラリ & コマンドラインツール** です。Python API とコマンドラインインターフェースの両方を提供しており、用途に応じて使い分けられます。
+
+## 何が実現できるか
+
+**世界初** のオープンソース CityGML → STEP 変換実装により、国交省 [PLATEAU](https://www.mlit.go.jp/plateau/) の 3D 都市モデルを **汎用 CAD ソフトで編集可能** にします。これまで「見るだけ」だった PLATEAU データを、CAD/BIM 環境で自由に加工・編集できるようになります。
+
+### 実現できること
+
+- **建築デザインへの活用**: PLATEAU の建物データを CAD で読み込み、リノベーション計画や都市開発プロジェクトの下地として利用
+- **3D プリント**: 建物モデルを CAD で調整・最適化して、3D プリンター用データを作成
+- **シミュレーション・解析**: 構造解析、熱解析、音響シミュレーションなどの CAD/CAE ツールに取り込み
+- **カスタマイズ**: 実在する建物データをベースに、デザイン変更や拡張を自由に実施
 
 <CardGrid>
-  <Card title="パース" icon="document">
-    ストリーミング対応で、どんなに大きい CityGML でもメモリ一定で処理できます。建物メタデータ、フットプリント、ジオメトリの抽出が可能。
+  <Card title="ライブラリとして" icon="rocket">
+    Python プロジェクトに組み込んで、CityGML の解析・変換・データ抽出を自動化。
+    ストリーミング API でメモリ消費を抑えた大規模処理が可能。
   </Card>
-  <Card title="変換" icon="setting">
-    OpenCASCADE で 3D 建物ジオメトリを STEP に変換。4つの変換方式と LoD 自動フォールバック、段階的なジオメトリ修復つき。
+  <Card title="CLI ツールとして" icon="laptop">
+    コマンドライン一発で CityGML を STEP に変換。スクリプトやパイプラインに組み込んで
+    バッチ処理やワークフローの自動化に利用できます。
   </Card>
-  <Card title="取得" icon="magnifier">
-    PLATEAU の公開 API から住所やメッシュコードで CityGML データを取得。ジオコーディング、ランキング、キャッシュを含む。
+  <Card title="PLATEAU データ連携" icon="magnifier">
+    住所やメッシュコードから PLATEAU の公開 API 経由で CityGML を自動取得。
+    日本全国の 3D 都市モデルに簡単アクセス。
   </Card>
-  <Card title="抽出" icon="list-format">
-    CityGML から 2D フットプリントと高さを抽出。OCCT 不要で動きます。
+  <Card title="柔軟な変換オプション" icon="setting">
+    4つの変換方式、LoD 自動フォールバック、段階的ジオメトリ修復により、
+    さまざまな品質の CityGML データに対応。
   </Card>
 </CardGrid>
 
@@ -43,7 +58,7 @@ CityGML 2.0 ファイルを読み込んで、CAD/BIM で使える STEP (ISO 1030
 # パースして概要を出力
 gml2step parse ./building.gml
 
-# STEP に変換
+# STEP に変換（CAD で開ける）
 gml2step convert ./building.gml ./output.step --method auto
 
 # フットプリント抽出
@@ -60,6 +75,6 @@ summary = parse("building.gml")
 for building, xlinks in stream_parse("building.gml"):
     process(building)
 
-# STEP 変換
+# STEP 変換（汎用 CAD で編集可能）
 ok, msg = convert("building.gml", "output.step", method="auto")
 ```


### PR DESCRIPTION
## Summary

ドキュメントサイトのトップページ（ランディングページ）を改善しました。PLATEAUデータをCADで編集可能にするという実用的な価値を前面に出し、ツールの性質（Pythonライブラリ & CLIツール）を明確にしました。

## Changes

### Hero section
- **tagline** を変更: 「CityGML を STEP に変換。PLATEAU データを CAD で編集可能に」
  - 実用的な価値（CADでの編集可能性）を強調
  - PLATEAUデータへの対応を明示

### New sections
- **「このツールについて」セクション追加** (EN: "About this tool")
  - Python ライブラリとコマンドラインツールの両方として使える点を明記
  - ユーザーが用途に応じて使い分けられることを説明

- **「何が実現できるか」セクション改善** (EN: "What you can achieve")
  - **世界初のオープンソース CityGML → STEP 変換実装**であることを明示
  - 「見るだけ」から「編集可能」への転換を強調

- **「実現できること」サブセクション追加** (EN: "Use cases")
  - 建築デザインへの活用
  - 3D プリント
  - シミュレーション・解析
  - カスタマイズ
  - 具体的なユースケースを示すことで、実用的な価値を伝える

### CardGrid redesign
従来の機能ベースの説明から、より実用的な価値を強調する構成に変更：
- 「ライブラリとして」「CLIツールとして」: ツールの二面性を明確化
- 「PLATEAUデータ連携」: 日本全国の3D都市モデルへの簡単アクセス
- 「柔軟な変換オプション」: さまざまな品質のデータに対応

### Code examples
- コメントを追加: 「CAD で開ける」「汎用 CAD で編集可能」など
- より実用シーンを想起させる説明に

## Impact

- **明確性**: ライブラリとCLIツールの両方として使えることが一目で分かる
- **独自性**: 世界初のOSS実装であることを明示
- **実用性**: CADでの編集可能性という具体的な価値を前面に
- **ユースケース**: 建築デザイン、3Dプリント、シミュレーションなど具体例を提示

## Before / After

### Before (tagline)
```
CityGML のパースと STEP 変換。CAD/BIM ワークフロー向け。
```

### After (tagline)
```
CityGML を STEP に変換。PLATEAU データを CAD で編集可能に
```

---

Closes #N/A (no related issue)